### PR TITLE
Update configuration for VS2010 and win64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@
 /tests/*.trs
 /Debug
 /Release
+/*/Debug
+/*/Release
 *.lo
 *.o
 /libjson-c.la

--- a/config.h.in
+++ b/config.h.in
@@ -134,6 +134,9 @@
    */
 #undef LT_OBJDIR
 
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+#undef NO_MINUS_C_MINUS_O
+
 /* Name of package */
 #undef PACKAGE
 

--- a/config.h.win32
+++ b/config.h.win32
@@ -8,35 +8,43 @@
 
 /* Define to 1 if you have the declaration of `INFINITY', and to 0 if you
    don't. */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define HAVE_DECL_INFINITY 1
+#endif
 
 /* Define to 1 if you have the declaration of `isinf', and to 0 if you don't.
    */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define HAVE_DECL_ISINF 1
+#endif
 
 /* Define to 1 if you have the declaration of `isnan', and to 0 if you don't.
    */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define HAVE_DECL_ISNAN 1
+#endif
 
 /* Define to 1 if you have the declaration of `nan', and to 0 if you don't. */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define HAVE_DECL_NAN 1
+#endif
 
 /* Define to 1 if you have the declaration of `_finite', and to 0 if you
    don't. */
-#define HAVE_DECL__FINITE 0
+#define HAVE_DECL__FINITE 1
 
 /* Define to 1 if you have the declaration of `_isnan', and to 0 if you don't.
    */
-#define HAVE_DECL__ISNAN 0
+#define HAVE_DECL__ISNAN 1
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#undef HAVE_DLFCN_H
+#define HAVE_DLFCN_H 1
 
 /* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
-#undef HAVE_DOPRNT
+#define HAVE_DOPRNT 1
 
 /* Define to 1 if you have the <endian.h> header file. */
-#define HAVE_ENDIAN_H 1
+#undef HAVE_ENDIAN_H
 
 /* Define to 1 if you have the <fcntl.h> header file. */
 #define HAVE_FCNTL_H 1
@@ -58,7 +66,7 @@
 #define HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the `open' function. */
-#undef HAVE_OPEN
+#define HAVE_OPEN 1
 
 /* Define to 1 if your system has a GNU libc compatible `realloc' function,
    and to 0 otherwise. */
@@ -95,13 +103,13 @@
 #define HAVE_STRING_H 1
 
 /* Define to 1 if you have the `strncasecmp' function. */
-#define HAVE_STRNCASECMP 1
+#undef HAVE_STRNCASECMP
 
 /* Define to 1 if you have the <syslog.h> header file. */
 #undef HAVE_SYSLOG_H
 
 /* Define to 1 if you have the <sys/cdefs.h> header file. */
-#undef HAVE_SYS_CDEFS_H
+#define HAVE_SYS_CDEFS_H 1
 
 /* Define to 1 if you have the <sys/param.h> header file. */
 #undef HAVE_SYS_PARAM_H
@@ -119,20 +127,20 @@
 #undef HAVE_VASPRINTF
 
 /* Define to 1 if you have the `vprintf' function. */
-#undef HAVE_VPRINTF
+#define HAVE_VPRINTF 1
 
 /* Define to 1 if you have the `vsnprintf' function. */
-#undef HAVE_VSNPRINTF
+#define HAVE_VSNPRINTF 1
 
 /* Define to 1 if you have the `vsyslog' function. */
 #undef HAVE_VSYSLOG
 
-/* Public define for json_inttypes.h */
-#define JSON_C_HAVE_INTTYPES_H 1
-
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #undef LT_OBJDIR
+
+/* Define to 1 if your C compiler doesn't accept -c and -o together. */
+/* #undef NO_MINUS_C_MINUS_O */
 
 /* Name of package */
 #define PACKAGE "json-c"

--- a/json-c.vcxproj
+++ b/json-c.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -20,7 +28,17 @@
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
@@ -31,7 +49,13 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -54,7 +78,42 @@ copy json_config.h.win32 json_config.h
       <Message>copy config.h from Windows template instead of calling configure</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <PreBuildEvent>
+      <Command>copy config.h.win32 config.h
+copy json_config.h.win32 json_config.h
+</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>copy config.h from Windows template instead of calling configure</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
+    </ClCompile>
+    <PreBuildEvent>
+      <Command>copy config.h.win32 config.h
+copy json_config.h.win32 json_config.h
+</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>copy config.h from Windows template instead of calling configure</Message>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level3</WarningLevel>

--- a/json-c.vcxproj
+++ b/json-c.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{04D8CDBE-FB3E-4362-87E6-07DC3C0083B2}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>jsonc</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -94,14 +94,16 @@ copy json_config.h.win32 json_config.h
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="arraylist.h" />
-    <ClInclude Include="bits.h" />
     <ClInclude Include="debug.h" />
+    <ClInclude Include="json_inttypes.h" />
     <ClInclude Include="json_object.h" />
     <ClInclude Include="json_object_private.h" />
     <ClInclude Include="json_tokener.h" />
     <ClInclude Include="json_util.h" />
     <ClInclude Include="linkhash.h" />
+    <ClInclude Include="math_compat.h" />
     <ClInclude Include="printbuf.h" />
+    <ClInclude Include="random_seed.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="config.h.win32" />

--- a/json-c.vcxproj
+++ b/json-c.vcxproj
@@ -137,6 +137,7 @@ copy json_config.h.win32 json_config.h
     <ClCompile Include="json_util.c" />
     <ClCompile Include="linkhash.c" />
     <ClCompile Include="printbuf.c" />
+    <ClCompile Include="random_seed.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="arraylist.h" />

--- a/json-c.vcxproj
+++ b/json-c.vcxproj
@@ -15,12 +15,12 @@
     <RootNamespace>jsonc</RootNamespace>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
@@ -28,59 +28,46 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <_ProjectFileVersion>12.0.30324.0</_ProjectFileVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <OutDir>Debug\</OutDir>
-    <IntDir>Debug\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <OutDir>Release\</OutDir>
-    <IntDir>Release\</IntDir>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)json-c.lib</OutputFile>
-    </Lib>
     <PreBuildEvent>
       <Command>copy config.h.win32 config.h
 copy json_config.h.win32 json_config.h
 </Command>
     </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>copy config.h from Windows template instead of calling configure</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
-    <Lib>
-      <OutputFile>$(OutDir)json-c.lib</OutputFile>
-    </Lib>
     <PreBuildEvent>
       <Command>copy config.h.win32 config.h
 copy json_config.h.win32 json_config.h
 </Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>copy config.h from Windows template instead of calling configure</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/json-c.vcxproj.filters
+++ b/json-c.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="printbuf.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="random_seed.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="arraylist.h">

--- a/json-c.vcxproj.filters
+++ b/json-c.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -14,7 +14,7 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx</Extensions>
     </Filter>
     <Filter Include="Documentation">
-      <UniqueIdentifier>{d3849076-874e-490e-858c-0871d04d1ecb}</UniqueIdentifier>
+      <UniqueIdentifier>{8c5a59ed-4639-4361-9b7c-ecdcd09b953c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -44,9 +44,6 @@
     <ClInclude Include="arraylist.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="bits.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="debug.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -68,14 +65,23 @@
     <ClInclude Include="printbuf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="json_inttypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="math_compat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="random_seed.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Doxyfile">
       <Filter>Documentation</Filter>
     </None>
     <None Include="config.h.win32" />
+    <None Include="json_config.h.win32" />
     <None Include="README-WIN32.html" />
     <None Include="README.html" />
-    <None Include="json_config.h.win32" />
   </ItemGroup>
 </Project>

--- a/json_config.h.win32
+++ b/json_config.h.win32
@@ -1,3 +1,5 @@
 
 /* Define to 1 if you have the <inttypes.h> header file. */
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #define JSON_C_HAVE_INTTYPES_H 1
+#endif

--- a/json_inttypes.h
+++ b/json_inttypes.h
@@ -4,24 +4,15 @@
 
 #include "json_config.h"
 
-#if defined(_MSC_VER) && _MSC_VER <= 1700
-
-/* Anything less than Visual Studio C++ 10 is missing stdint.h and inttypes.h */
-typedef __int32 int32_t;
-#define INT32_MIN    ((int32_t)_I32_MIN)
-#define INT32_MAX    ((int32_t)_I32_MAX)
-typedef __int64 int64_t;
-#define INT64_MIN    ((int64_t)_I64_MIN)
-#define INT64_MAX    ((int64_t)_I64_MAX)
-#define PRId64 "I64d"
-#define SCNd64 "I64d"
+#ifdef JSON_C_HAVE_INTTYPES_H
+/* inttypes.h includes stdint.h */
+#include <inttypes.h>
 
 #else
+#include <stdint.h>
 
-#ifdef JSON_C_HAVE_INTTYPES_H
-#include <inttypes.h>
-#endif
-/* inttypes.h includes stdint.h */
+#define PRId64 "I64d"
+#define SCNd64 "I64d"
 
 #endif
 

--- a/json_object.c
+++ b/json_object.c
@@ -409,7 +409,7 @@ void json_object_object_add(struct json_object* jso, const char *key,
 		lh_table_insert(jso->o.c_object, strdup(key), val);
 		return;
 	}
-	existing_value = (void *)existing_entry->v;
+	existing_value = (json_object  *)existing_entry->v;
 	if (existing_value)
 		json_object_put(existing_value);
 	existing_entry->v = val;
@@ -661,8 +661,8 @@ struct json_object* json_object_new_double_s(double d, const char *ds)
 int json_object_userdata_to_json_string(struct json_object *jso,
 	struct printbuf *pb, int level, int flags)
 {
-	int userdata_len = strlen(jso->_userdata);
-	printbuf_memappend(pb, jso->_userdata, userdata_len);
+	int userdata_len = strlen((const char *)jso->_userdata);
+	printbuf_memappend(pb, (const char *)jso->_userdata, userdata_len);
 	return userdata_len;
 }
 

--- a/json_tokener.c
+++ b/json_tokener.c
@@ -16,6 +16,7 @@
 #include "config.h"
 
 #include <math.h>
+#include "math_compat.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -353,7 +354,7 @@ struct json_object* json_tokener_parse_ex(struct json_tokener *tok,
 
     case json_tokener_state_inf: /* aka starts with 'i' */
       {
-	int size_inf;
+	size_t size_inf;
 	int is_negative = 0;
 
 	printbuf_memappend_fast(tok->pb, &c, 1);

--- a/linkhash.c
+++ b/linkhash.c
@@ -10,6 +10,8 @@
  *
  */
 
+#include "config.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/linkhash.c
+++ b/linkhash.c
@@ -415,7 +415,7 @@ unsigned long lh_char_hash(const void *k)
 #if defined __GNUC__
 		__sync_val_compare_and_swap(&random_seed, -1, seed);
 #elif defined _MSC_VER
-		InterlockedCompareExchange(&random_seed, seed, -1);
+		InterlockedCompareExchange((LONG *)&random_seed, seed, -1);
 #else
 #warning "racy random seed initializtion if used by multiple threads"
 		random_seed = seed; /* potentially racy */

--- a/math_compat.h
+++ b/math_compat.h
@@ -1,7 +1,7 @@
 #ifndef __math_compat_h
 #define __math_compat_h
 
-/* Define isnan and isinf on Windows/MSVC */
+/* Define isnan, isinf, infinity and nan on Windows/MSVC */
 
 #ifndef HAVE_DECL_ISNAN
 # ifdef HAVE_DECL__ISNAN
@@ -17,12 +17,15 @@
 # endif
 #endif
 
-#ifndef HAVE_DECL_NAN
-#error This platform does not have nan()
+#ifndef HAVE_DECL_INFINITY
+#include <float.h>
+#define INFINITY (DBL_MAX + DBL_MAX)
+#define HAVE_DECL_INFINITY
 #endif
 
-#ifndef HAVE_DECL_INFINITY
-#error This platform does not have INFINITY
+#ifndef HAVE_DECL_NAN
+#define NAN (INFINITY - INFINITY)
+#define HAVE_DECL_NAN
 #endif
 
 #endif

--- a/random_seed.c
+++ b/random_seed.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include "config.h"
+#include "random_seed.h"
 
 #define DEBUG_SEED(s)
 


### PR DESCRIPTION
Update config.h.win32 and json_config.h.win32 for vs2010/winsdk71 as well
Update build configurations for vs2010/winsdk71
Add x64 build configurations
Simplified json_inttypes.h and math_compat.h

Seems to build successfully with all combinations of the following settings:
- Debug and Release configurations
- win32 and win64 targets
- winsdk71 and vs2013 platforms
